### PR TITLE
Re-add derives to structs where possible

### DIFF
--- a/src/types/entities/application.rs
+++ b/src/types/entities/application.rs
@@ -96,7 +96,7 @@ impl Application {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /// # Reference
 /// See <https://discord.com/developers/docs/resources/application#install-params-object>
 pub struct InstallParams {
@@ -157,7 +157,7 @@ pub struct ApplicationCommandOption {
     pub options: Arc<Mutex<Vec<ApplicationCommandOption>>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ApplicationCommandOptionChoice {
     pub name: String,
     pub value: Value,
@@ -209,7 +209,7 @@ pub struct GuildApplicationCommandPermissions {
     pub permissions: Vec<Arc<Mutex<ApplicationCommandPermission>>>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 /// See <https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure>
 pub struct ApplicationCommandPermission {
     pub id: Snowflake,

--- a/src/types/entities/attachment.rs
+++ b/src/types/entities/attachment.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::utils::Snowflake;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 /// # Reference
 /// See <https://discord.com/developers/docs/resources/channel#attachment-object>

--- a/src/types/entities/channel.rs
+++ b/src/types/entities/channel.rs
@@ -122,7 +122,7 @@ pub struct Tag {
     pub emoji_name: Option<String>,
 }
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, PartialOrd)]
 pub struct PermissionOverwrite {
     pub id: Snowflake,
     #[serde(rename = "type")]
@@ -136,7 +136,7 @@ pub struct PermissionOverwrite {
     pub deny: String,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// # Reference
 /// See <https://discord-userdoccers.vercel.app/resources/channel#thread-metadata-object>
 pub struct ThreadMetadata {
@@ -159,7 +159,7 @@ pub struct ThreadMember {
     pub member: Option<Arc<Mutex<GuildMember>>>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 /// Specifies the emoji to use as the default way to react to a [ChannelType::GuildForum] or [ChannelType::GuildMedia] channel post.
 ///
 /// # Reference

--- a/src/types/entities/guild.rs
+++ b/src/types/entities/guild.rs
@@ -93,7 +93,7 @@ pub struct Guild {
 }
 
 /// See <https://docs.spacebar.chat/routes/#get-/guilds/-guild_id-/bans/-user->
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct GuildBan {
     pub user_id: Snowflake,
@@ -124,13 +124,13 @@ pub struct GuildInvite {
     pub vanity_url: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct UnavailableGuild {
     id: Snowflake,
     unavailable: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct GuildCreateResponse {
     pub id: Snowflake,
 }

--- a/src/types/entities/invite.rs
+++ b/src/types/entities/invite.rs
@@ -58,7 +58,7 @@ pub struct InviteGuild {
 
 /// See <https://discord-userdoccers.vercel.app/resources/guild#nsfw-level> for an explanation on what
 /// the levels mean.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum NSFWLevel {
     Default = 0,

--- a/src/types/entities/message.rs
+++ b/src/types/entities/message.rs
@@ -67,7 +67,7 @@ pub struct Message {
     pub role_subscription_data: Option<RoleSubscriptionData>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// # Reference
 /// See <https://discord-userdoccers.vercel.app/resources/message#message-reference-object>
 pub struct MessageReference {
@@ -87,7 +87,7 @@ pub struct MessageInteraction {
     pub member: Option<GuildMember>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct AllowedMention {
     parse: Vec<AllowedMentionType>,
     roles: Vec<Snowflake>,
@@ -95,7 +95,7 @@ pub struct AllowedMention {
     replied_user: bool,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum AllowedMentionType {
     Roles,
@@ -103,7 +103,7 @@ pub enum AllowedMentionType {
     Everyone,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChannelMention {
     pub id: Snowflake,
     pub guild_id: Snowflake,
@@ -130,14 +130,14 @@ pub struct Embed {
     fields: Option<Vec<EmbedField>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct EmbedFooter {
     text: String,
     icon_url: Option<String>,
     proxy_icon_url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct EmbedImage {
     url: String,
     proxy_url: String,
@@ -145,7 +145,7 @@ pub struct EmbedImage {
     width: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct EmbedThumbnail {
     url: String,
     proxy_url: Option<String>,
@@ -153,7 +153,7 @@ pub struct EmbedThumbnail {
     width: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 struct EmbedVideo {
     url: Option<String>,
     proxy_url: Option<String>,
@@ -161,13 +161,13 @@ struct EmbedVideo {
     width: Option<i32>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct EmbedProvider {
     name: Option<String>,
     url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct EmbedAuthor {
     name: String,
     url: Option<String>,
@@ -175,7 +175,7 @@ pub struct EmbedAuthor {
     proxy_icon_url: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct EmbedField {
     name: String,
     value: String,
@@ -192,7 +192,7 @@ pub struct Reaction {
     pub emoji: Emoji,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]
 pub enum Component {
     ActionRow = 1,
     Button = 2,
@@ -204,7 +204,7 @@ pub enum Component {
     ChannelSelect = 8,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// # Reference
 /// See <https://discord-userdoccers.vercel.app/resources/message#message-activity-object>
 pub struct MessageActivity {

--- a/src/types/entities/role.rs
+++ b/src/types/entities/role.rs
@@ -26,7 +26,7 @@ pub struct RoleObject {
     pub tags: Option<RoleTags>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RoleSubscriptionData {
     pub role_subscription_listing_id: Snowflake,
     pub tier_name: String,

--- a/src/types/entities/security_key.rs
+++ b/src/types/entities/security_key.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::utils::Snowflake;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct SecurityKey {
     pub id: String,

--- a/src/types/entities/sticker.rs
+++ b/src/types/entities/sticker.rs
@@ -28,7 +28,7 @@ pub struct Sticker {
     pub sort_value: Option<u8>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 /// A partial sticker object.
 ///
 /// Represents the smallest amount of data required to render a sticker.

--- a/src/types/entities/user.rs
+++ b/src/types/entities/user.rs
@@ -3,7 +3,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_aux::prelude::deserialize_option_number_from_string;
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 pub struct UserData {
     pub valid_tokens_since: DateTime<Utc>,
@@ -15,7 +15,7 @@ impl User {
         PublicUser::from(self)
     }
 }
-#[derive(Serialize, Deserialize, Debug, Default, Clone)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct User {
     pub id: Snowflake,
@@ -50,7 +50,7 @@ pub struct User {
     pub disabled: Option<bool>,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PublicUser {
     pub id: Snowflake,
     pub username: Option<String>,

--- a/src/types/entities/user_settings.rs
+++ b/src/types/entities/user_settings.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use chrono::{serde::ts_milliseconds_option, Utc};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "lowercase")]
 pub enum UserStatus {
@@ -21,7 +21,7 @@ impl std::fmt::Display for UserStatus {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::Type))]
 #[serde(rename_all = "lowercase")]
 pub enum UserTheme {
@@ -119,7 +119,7 @@ impl Default for UserSettings {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "sqlx", derive(sqlx::FromRow))]
 pub struct CustomStatus {
     pub emoji_id: Option<String>,
@@ -129,7 +129,7 @@ pub struct CustomStatus {
     pub text: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FriendSourceFlags {
     pub all: bool,
 }

--- a/src/types/schema/channel.rs
+++ b/src/types/schema/channel.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::types::{entities::PermissionOverwrite, Snowflake};
 
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize, Default, PartialEq, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub struct ChannelCreateSchema {
     pub name: String,
@@ -27,7 +27,7 @@ pub struct ChannelCreateSchema {
     pub video_quality_mode: Option<i32>,
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[derive(Debug, Deserialize, Serialize, Clone, Default, PartialEq, PartialOrd)]
 #[serde(rename_all = "snake_case")]
 pub struct ChannelModifySchema {
     pub name: Option<String>,


### PR DESCRIPTION
Some derives were unnecessarily removed from structs, where they are actually fully valid.

This pr fixes that minor mistake :)